### PR TITLE
Lock faraday dependency to < 0.9.0 to fix errors.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.0.0'
 
+gem 'faraday', '< 0.9.0'
 gem 'desk_api', '0.5.0'
 gem 'rubyzip', '1.1.0'
 gem 'open_uri_redirections', '0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     desk_api (0.5.0)
       addressable
       faraday
       faraday_middleware
       hashie
       simple_oauth
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    hashie (3.4.4)
-    multipart-post (2.0.0)
+    faraday (0.8.11)
+      multipart-post (~> 1.2.0)
+    faraday_middleware (0.11.0)
+      faraday (>= 0.7.4, < 1.0)
+    hashie (3.4.6)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    mini_portile2 (2.1.0)
+    multipart-post (1.2.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     open_uri_redirections (0.1.4)
+    public_suffix (2.0.5)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
     rubyzip (1.1.0)
     simple_oauth (0.3.1)
 
@@ -23,8 +32,13 @@ PLATFORMS
 
 DEPENDENCIES
   desk_api (= 0.5.0)
+  faraday (< 0.9.0)
   open_uri_redirections (= 0.1.4)
+  rails-html-sanitizer
   rubyzip (= 1.1.0)
 
+RUBY VERSION
+   ruby 2.0.0p648
+
 BUNDLED WITH
-   1.11.2
+   1.13.7


### PR DESCRIPTION
I had to lock faraday at a lower version as this gem was using `register_middleware` which was removed in newer versions of `faraday`. I also upgraded `bundler` since I was unable to run `bundle install` using `1.11.2` due to installation issues with Nokogiri.