### PR TITLE
Update desk_api version to avoid errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
-ruby '2.0.0'
+ruby '>= 2.0.0'
 
-gem 'desk_api', '0.5.0'
+gem 'desk_api', '0.6.2'
 gem 'rubyzip', '1.1.0'
 gem 'open_uri_redirections', '0.1.4'
 gem 'rails-html-sanitizer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,26 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    desk_api (0.5.0)
-      addressable
-      faraday
-      faraday_middleware
-      hashie
-      simple_oauth
-    faraday (0.9.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    crass (1.0.4)
+    desk_api (0.6.2)
+      addressable (>= 2.3, < 2.6)
+      faraday (>= 0.8, < 1.0)
+      simple_oauth (>= 0.1, < 0.4)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    hashie (3.4.4)
-    multipart-post (2.0.0)
+    loofah (2.2.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mini_portile2 (2.4.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     open_uri_redirections (0.1.4)
+    public_suffix (3.1.1)
+    rails-html-sanitizer (1.2.0)
+      loofah (~> 2.2, >= 2.2.2)
     rubyzip (1.1.0)
     simple_oauth (0.3.1)
 
@@ -22,9 +28,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  desk_api (= 0.5.0)
+  desk_api (= 0.6.2)
   open_uri_redirections (= 0.1.4)
+  rails-html-sanitizer
   rubyzip (= 1.1.0)
 
+RUBY VERSION
+   ruby 2.5.5p157
+
 BUNDLED WITH
-   1.11.2
+   1.17.3


### PR DESCRIPTION
Update the desk_api ruby gem to 0.6.2 which is compatible with faraday < 1.0 as specified in the Gem dependencies.
This fixes the issue opened in #2 and another error was the ruby version missing a `>=` leading to other errors when trying to do a `bundle install --path vendor/bundle`.

After that is changed I was able to run the script without issue.
Fixes: #2 